### PR TITLE
Skip long_double_value visitor when FMT_USE_FLOAT128=0

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1690,7 +1690,11 @@ FMT_CONSTEXPR FMT_INLINE auto visit_format_arg(
   case detail::type::double_type:
     return vis(arg.value_.double_value);
   case detail::type::long_double_type:
+#if FMT_USE_FLOAT128
     return vis(arg.value_.long_double_value);
+#else
+    break;
+#endif
   case detail::type::cstring_type:
     return vis(arg.value_.string.data);
   case detail::type::string_type:


### PR DESCRIPTION
There is a macro FMT_USE_FLOAT128 which is defined as 0 or 1, but it is not tested in visit_format_arg, and raises errors in some specific situations. For example: according to #3106, libc++ implementations of device functions do not support long double, so there are errors in visit_format_arg even when defining FMT_USE_FLOAT128=0